### PR TITLE
Agregar revisión técnica y planes de sprint (documentación y issues)

### DIFF
--- a/Documents/REVISION_PROYECTO.md
+++ b/Documents/REVISION_PROYECTO.md
@@ -1,0 +1,124 @@
+# Revisión técnica del proyecto MCC Agent
+
+## 1) Objetivo principal identificado
+
+El proyecto **MCC Agent** es una aplicación Android cuyo objetivo principal es actuar como un **agente intermedio entre un backend y la telefonía del dispositivo**, permitiendo:
+
+- autenticación de usuario contra API,
+- obtención de mensajes pendientes desde servidor,
+- envío de SMS desde el teléfono,
+- y retroalimentación del estado de entrega al backend.
+
+Este comportamiento sugiere un caso de uso operativo (pasarela/bridge SMS) donde el dispositivo ejecuta tareas de sincronización periódicas y persistentes incluso tras reinicios.
+
+## 2) Funcionalidades actuales del sistema
+
+### 2.1 Autenticación y sesión
+
+- Pantalla de login con usuario/contraseña y gestión de token.
+- Renovación de token implementada en cliente de red.
+- Cierre de sesión mediante `SessionManager`.
+
+### 2.2 Configuración de entornos
+
+- Pantalla de configuración para URLs de **DEV/PREPROD/PROD**.
+- Selección de entorno activo y persistencia en `SharedPreferences`.
+- Validación básica de formato URL y prueba de conectividad.
+
+### 2.3 Integración con API
+
+- Cliente Retrofit con interceptores de autorización.
+- Carga de certificado según entorno para TLS custom.
+- Endpoints para login, cliente, dispositivos, mensajes y actualización de estado.
+
+### 2.4 Orquestación de envío SMS
+
+- Scheduler con WorkManager (`SmsWorkScheduler`) para sincronización diferida.
+- Worker (`SmsSyncWorker`) que consulta mensajes pendientes y dispara envío por `SmsManager`.
+- Receiver (`SmsSentReceiver`) que recibe resultado del envío y notifica estado al backend.
+- Rearme automático al reiniciar dispositivo vía `BootReceiver`.
+
+### 2.5 Interfaz y navegación
+
+- UI en Jetpack Compose.
+- Navegación entre login, home y settings.
+
+## 3) Hallazgos técnicos y defectos potenciales
+
+## 3.1 Seguridad
+
+1. **`usesCleartextTraffic=true` en manifiesto**.
+   - Permite tráfico HTTP no cifrado si se utiliza accidentalmente una URL insegura.
+
+2. **Logging de red en nivel BODY sin condicionarlo por build type**.
+   - Riesgo de exponer tokens, payloads sensibles y datos de operación en logs.
+
+3. **Token en `SharedPreferences` sin cifrado**.
+   - Riesgo en dispositivos comprometidos o con respaldos inseguros.
+
+4. **Permisos amplios de SMS siempre declarados**.
+   - Correcto para el caso de uso, pero requiere endurecer justificación y gobernanza de uso para publicación/distribución.
+
+## 3.2 Robustez y arquitectura
+
+1. **Redundancia en la capa de envío SMS**.
+   - Conviven `SMSService` (foreground loop) y `SmsSyncWorker` (WorkManager), con indicios de uso mixto y código legado comentado.
+   - Esto incrementa complejidad operativa y riesgo de duplicidad de envíos.
+
+2. **Código comentado extenso en producción**.
+   - Dificulta mantenimiento y revisión de comportamiento real.
+
+3. **Colisión potencial de `PendingIntent`**.
+   - En worker y servicio se usa requestCode fijo (`0`), lo que puede provocar reutilización no deseada entre mensajes.
+
+4. **Navegación inicial fija en login**.
+   - No se observa evaluación explícita del estado de sesión para definir destino inicial.
+
+5. **Inconsistencia menor en `SettingsScreen`**.
+   - Se recibe `context` por parámetro pero se vuelve a declarar localmente con `LocalContext.current`.
+
+6. **Interfaz API con duplicidad semántica de renovación**.
+   - Existen `renew()` y `renewToken()` apuntando al mismo endpoint.
+
+## 3.3 Calidad y deuda técnica
+
+1. **Dependencias duplicadas en Gradle** (ej. Compose/UI/Core declaradas varias veces).
+2. **Pruebas unitarias/instrumentadas de plantilla** sin cobertura funcional relevante del dominio.
+3. **Valores por defecto de URL potencialmente no productivos** (ej. host de desarrollo local).
+
+## 4) Mejoras recomendadas (priorizadas)
+
+## Prioridad alta (seguridad y operación)
+
+1. **Eliminar `usesCleartextTraffic=true` en producción** y limitar HTTP únicamente a entornos internos controlados mediante `network_security_config` por flavor.
+2. **Restringir logging HTTP a builds debug** y sanitizar cabeceras sensibles.
+3. **Migrar token a almacenamiento cifrado** (p. ej. `EncryptedSharedPreferences` o Jetpack Security).
+4. **Unificar estrategia de ejecución**: elegir WorkManager *o* Foreground Service como camino único para envío de SMS.
+5. **Corregir requestCode de `PendingIntent`** usando `mid.hashCode()` para evitar colisiones.
+
+## Prioridad media (mantenibilidad)
+
+1. **Eliminar código comentado legado** y conservar historial en Git.
+2. **Refactorizar `SettingsScreen`** para evitar sombra de variables y simplificar estado.
+3. **Consolidar contrato de API** eliminando duplicidades (`renew` vs `renewToken`).
+4. **Revisar `startDestination`** con lógica de sesión persistida.
+
+## Prioridad baja (calidad continua)
+
+1. **Limpieza de dependencias duplicadas** en `build.gradle.kts`.
+2. **Agregar pruebas de dominio**:
+   - parsing/expiración de JWT,
+   - validación de URL de entornos,
+   - mapeo de estados de envío SMS,
+   - comportamiento de reintentos/backoff.
+3. **Definir documentación operativa** para despliegue por entorno y rotación de certificados.
+
+## 5) Propuesta de hoja de ruta breve
+
+- **Fase 1 (rápida):** endurecimiento de seguridad (cleartext/logs/token) y limpieza de código comentado.
+- **Fase 2:** consolidación de arquitectura de ejecución SMS y robustez de intents/reintentos.
+- **Fase 3:** pruebas automatizadas de negocio + mejora de DX (build limpio, documentación técnica).
+
+## 6) Conclusión
+
+El proyecto tiene una base funcional sólida para su propósito de agente SMS con backend, pero presenta riesgos típicos de una solución que evolucionó rápido (seguridad de transporte/credenciales, doble mecanismo de ejecución y deuda técnica). Atacar primero seguridad y simplificación operativa ofrecerá la mayor reducción de riesgo con impacto directo en estabilidad y mantenibilidad.

--- a/Documents/SPRINT_1_GITHUB_ISSUES.md
+++ b/Documents/SPRINT_1_GITHUB_ISSUES.md
@@ -1,0 +1,191 @@
+# Sprint 1 — Lista de incidencias para GitHub
+
+Este sprint implementa la **Fase 1** definida en la hoja de ruta: endurecimiento de seguridad y limpieza inicial para estabilizar la operación.
+
+## Objetivo del sprint
+
+Reducir riesgos críticos de seguridad y deuda técnica operativa con cambios de bajo impacto funcional y alto impacto en confiabilidad.
+
+## Duración sugerida
+
+- 2 semanas
+
+## Estructura recomendada en GitHub
+
+- Hito: `Sprint 1 - Seguridad y saneamiento`
+- Etiquetas sugeridas:
+  - `sprint-1`
+  - `seguridad`
+  - `arquitectura`
+  - `android`
+  - `deuda-tecnica`
+  - `prioridad:alta`
+
+---
+
+## Incidencia 1: Endurecer política de tráfico seguro por entorno
+
+**Título sugerido:** `Seguridad: restringir tráfico en texto plano y aplicar configuración de seguridad de red por entorno`
+
+**Tipo:** Seguridad / Configuración
+
+**Descripción:**
+Actualmente la aplicación permite tráfico no cifrado (`usesCleartextTraffic=true`). Se debe restringir el tráfico HTTP en producción y mantener excepciones controladas solo en entornos internos cuando corresponda.
+
+**Tareas:**
+- Definir política por sabor y tipo de compilación para DEV, PREPROD y PROD.
+- Ajustar `AndroidManifest.xml` para no permitir tráfico en texto plano de forma global.
+- Configurar `network_security_config` específico por entorno.
+- Validar conectividad HTTPS en cada entorno soportado.
+
+**Criterios de aceptación:**
+- En producción no se permite tráfico HTTP plano.
+- Cualquier excepción de texto plano queda limitada y documentada por entorno.
+- La aplicación mantiene conectividad en endpoints válidos HTTPS.
+
+**Estimación:** 5 puntos
+
+---
+
+## Incidencia 2: Limitar registro HTTP a depuración y ocultar datos sensibles
+
+**Título sugerido:** `Seguridad: restringir registros HTTP a depuración y sanitizar credenciales`
+
+**Tipo:** Seguridad / Observabilidad
+
+**Descripción:**
+El registro en nivel BODY puede exponer tokens y datos sensibles. Debe quedar habilitado solo para depuración y con sanitización mínima de cabeceras sensibles.
+
+**Tareas:**
+- Condicionar `HttpLoggingInterceptor` por `BuildConfig.DEBUG`.
+- Evitar impresión de `Authorization` y otros secretos.
+- Revisar registros de errores para no incluir tokens ni datos personales.
+- Actualizar guía de depuración segura.
+
+**Criterios de aceptación:**
+- En compilación de producción no se registran cuerpos de solicitud/respuesta.
+- No se registran tokens ni cabeceras sensibles en ninguna compilación.
+- Se conserva trazabilidad suficiente para diagnóstico técnico.
+
+**Estimación:** 3 puntos
+
+---
+
+## Incidencia 3: Migrar token a almacenamiento cifrado
+
+**Título sugerido:** `Seguridad: migrar sesión a almacenamiento cifrado`
+
+**Tipo:** Seguridad / Persistencia
+
+**Descripción:**
+El token de autenticación se guarda en `SharedPreferences` sin cifrado. Debe migrarse a almacenamiento seguro.
+
+**Tareas:**
+- Integrar almacenamiento cifrado (`EncryptedSharedPreferences` o equivalente).
+- Implementar migración no disruptiva de token existente.
+- Ajustar lectura/escritura de sesión en componentes afectados.
+- Verificar comportamiento de inicio de sesión, renovación y cierre de sesión.
+
+**Criterios de aceptación:**
+- El token no se guarda en texto plano.
+- La sesión previa se migra correctamente sin romper el inicio de sesión.
+- El cierre de sesión elimina credenciales de forma segura.
+
+**Estimación:** 5 puntos
+
+---
+
+## Incidencia 4: Unificar mecanismo de ejecución SMS
+
+**Título sugerido:** `Arquitectura: consolidar envío SMS en un único mecanismo de ejecución`
+
+**Tipo:** Arquitectura / Operación
+
+**Descripción:**
+Existen dos estrategias (`SMSService` y `SmsSyncWorker`) con riesgo de duplicidad y mayor complejidad. Debe elegirse una única estrategia de ejecución.
+
+**Tareas:**
+- Definir decisión técnica (preferencia sugerida: WorkManager para sincronización periódica controlada).
+- Eliminar rutas no usadas y código muerto/comentado.
+- Ajustar reprogramación en reinicio al mecanismo elegido.
+- Validar ausencia de envíos duplicados en escenarios de reintento.
+
+**Criterios de aceptación:**
+- Solo existe un flujo activo de envío de SMS.
+- No hay doble programación ni competencia entre worker/servicio.
+- El flujo sigue operativo tras reinicio del dispositivo.
+
+**Estimación:** 8 puntos
+
+---
+
+## Incidencia 5: Corregir colisiones de PendingIntent en envíos SMS
+
+**Título sugerido:** `Confiabilidad: evitar colisiones de PendingIntent por mensaje`
+
+**Tipo:** Robustez / Mensajería
+
+**Descripción:**
+El uso de `requestCode` fijo puede provocar reutilización no deseada de intents y estados incorrectos por mensaje.
+
+**Tareas:**
+- Usar `requestCode` único por `mid` (por ejemplo `mid.hashCode()`).
+- Revisar coherencia en `SmsSyncWorker` y en la ruta de envío adoptada.
+- Probar múltiples mensajes en cola con resultados mixtos (éxito/fallo).
+
+**Criterios de aceptación:**
+- Cada SMS mantiene correlación correcta con su confirmación de estado.
+- No se observan colisiones en pruebas con lotes de mensajes.
+
+**Estimación:** 3 puntos
+
+---
+
+## Incidencia 6: Limpieza inicial de deuda técnica visible
+
+**Título sugerido:** `Deuda técnica: eliminar código comentado legado y duplicidades inmediatas`
+
+**Tipo:** Deuda técnica
+
+**Descripción:**
+Existe código comentado extenso y duplicidades que dificultan mantenimiento y revisión.
+
+**Tareas:**
+- Eliminar bloques comentados obsoletos.
+- Remover duplicidades obvias en contrato API (renovación de token duplicada).
+- Registrar decisiones en bitácora técnica del sprint.
+
+**Criterios de aceptación:**
+- Código fuente sin bloques comentados de implementaciones viejas.
+- Contrato de API sin duplicidades funcionales innecesarias.
+- Revisión de pares aprobada por legibilidad y mantenibilidad.
+
+**Estimación:** 3 puntos
+
+---
+
+## Definición de terminado del sprint
+
+- Todas las incidencias cerradas con solicitud de extracción vinculada.
+- Validación técnica en entorno de pruebas.
+- Lista de verificación de seguridad actualizada.
+- Documento de decisiones arquitectónicas del sprint publicado.
+
+## Dependencias sugeridas
+
+1. Incidencia 1
+2. Incidencia 2
+3. Incidencia 3
+4. Incidencia 4
+5. Incidencia 5
+6. Incidencia 6
+
+## Comandos sugeridos (si se usa GitHub CLI)
+
+> Requiere repositorio con remoto configurado y autenticación previa con `gh auth login`.
+
+- Crear hito:
+  - `gh api repos/<owner>/<repo>/milestones -f title='Sprint 1 - Seguridad y saneamiento' -f state='open'`
+- Crear incidencia:
+  - `gh issue create --title '<titulo>' --body-file <archivo.md> --label sprint-1 --label prioridad:alta`
+

--- a/Documents/SPRINT_2_GITHUB_ISSUES.md
+++ b/Documents/SPRINT_2_GITHUB_ISSUES.md
@@ -1,0 +1,194 @@
+# Sprint 2 — Lista de incidencias para GitHub
+
+Este sprint implementa la **Fase 2** de la hoja de ruta: consolidación de arquitectura de ejecución SMS y fortalecimiento de confiabilidad operativa.
+
+## Objetivo del sprint
+
+Simplificar la arquitectura de envío, mejorar robustez ante fallos y asegurar trazabilidad técnica en la sincronización de mensajes SMS.
+
+## Duración sugerida
+
+- 2 semanas
+
+## Estructura recomendada en GitHub
+
+- Hito: `Sprint 2 - Consolidación operativa SMS`
+- Etiquetas sugeridas:
+  - `sprint-2`
+  - `arquitectura`
+  - `mensajeria`
+  - `confiabilidad`
+  - `android`
+  - `prioridad:alta`
+
+---
+
+## Incidencia 1: Implementar arquitectura única de envío SMS
+
+**Título sugerido:** `Arquitectura: activar un único flujo de envío SMS en producción`
+
+**Tipo:** Arquitectura / Operación
+
+**Descripción:**
+Luego del saneamiento inicial, se debe cerrar la transición y operar con una única ruta de ejecución de envíos para evitar duplicidad y estados inconsistentes.
+
+**Tareas:**
+- Consolidar definitivamente la estrategia aprobada (WorkManager o Servicio en primer plano).
+- Eliminar invocaciones remanentes de la estrategia descartada.
+- Revisar inicialización desde `MainActivity` y arranque posterior a reinicio.
+- Documentar decisión técnica y consecuencias de diseño.
+
+**Criterios de aceptación:**
+- Existe un solo mecanismo activo de envío.
+- No se detectan ejecuciones simultáneas de dos rutas.
+- La aplicación reanuda el flujo correctamente tras reinicio.
+
+**Estimación:** 8 puntos
+
+---
+
+## Incidencia 2: Estandarizar política de reintentos y backoff
+
+**Título sugerido:** `Confiabilidad: definir política unificada de reintentos y backoff`
+
+**Tipo:** Robustez / Operación
+
+**Descripción:**
+Los reintentos y tiempos de espera deben seguir una política clara para evitar saturación, retardos excesivos y comportamientos impredecibles.
+
+**Tareas:**
+- Definir tabla de tiempos de reintento por tipo de error.
+- Unificar lógica de espera y recuperación en el flujo activo.
+- Diferenciar errores recuperables de no recuperables.
+- Agregar métricas mínimas en registros para auditoría operativa.
+
+**Criterios de aceptación:**
+- Existe política documentada de reintentos.
+- Los reintentos siguen comportamiento consistente ante fallos.
+- Se evita ciclo agresivo de reenvío continuo.
+
+**Estimación:** 5 puntos
+
+---
+
+## Incidencia 3: Mejorar correlación de mensajes y confirmaciones
+
+**Título sugerido:** `Mensajería: robustecer correlación entre envío SMS y estado reportado`
+
+**Tipo:** Mensajería / Integración
+
+**Descripción:**
+Es necesario reforzar la correlación entre cada envío y su actualización de estado para prevenir reportes incorrectos en backend.
+
+**Tareas:**
+- Validar `requestCode` único por mensaje en toda la ruta activa.
+- Estandarizar metadatos mínimos por envío (`mid`, timestamp, resultado).
+- Revisar manejo de callbacks de envío exitoso/fallido.
+- Asegurar idempotencia básica en actualización de estado.
+
+**Criterios de aceptación:**
+- Cada confirmación corresponde al `mid` correcto.
+- No hay colisiones de intents entre mensajes concurrentes.
+- No se generan actualizaciones duplicadas por el mismo evento.
+
+**Estimación:** 5 puntos
+
+---
+
+## Incidencia 4: Endurecer gestión de errores de red en repositorios
+
+**Título sugerido:** `Integración: normalizar manejo de errores de red y respuestas API`
+
+**Tipo:** Integración / Calidad
+
+**Descripción:**
+El manejo de errores debe ser homogéneo para mejorar diagnóstico y evitar silencios operativos cuando falla el backend.
+
+**Tareas:**
+- Definir modelo común de error para repositorios de mensajes/autenticación.
+- Incorporar clasificación de errores HTTP y excepciones de transporte.
+- Mejorar mensajes de diagnóstico sin exponer datos sensibles.
+- Validar que fallos temporales no rompen el ciclo de sincronización.
+
+**Criterios de aceptación:**
+- Los errores quedan clasificados y trazables.
+- El flujo continúa en condiciones recuperables.
+- Los registros no exponen secretos.
+
+**Estimación:** 3 puntos
+
+---
+
+## Incidencia 5: Revisar navegación y estado de sesión al inicio
+
+**Título sugerido:** `Experiencia: definir destino inicial según estado de sesión`
+
+**Tipo:** Experiencia / Arquitectura
+
+**Descripción:**
+La navegación inicial debe responder al estado de autenticación para reducir fricción de uso y comportamientos ambiguos.
+
+**Tareas:**
+- Evaluar token/sesión al iniciar la app.
+- Definir destino inicial dinámico en navegación.
+- Evitar estados intermedios inconsistentes entre login y home.
+- Validar comportamiento en login, logout y token vencido.
+
+**Criterios de aceptación:**
+- El destino inicial refleja el estado real de sesión.
+- El usuario autenticado no regresa innecesariamente a login.
+- El token vencido redirige correctamente al flujo de autenticación.
+
+**Estimación:** 3 puntos
+
+---
+
+## Incidencia 6: Cierre de deuda técnica de la capa de red
+
+**Título sugerido:** `Deuda técnica: eliminar duplicidades y simplificar contrato de API`
+
+**Tipo:** Deuda técnica
+
+**Descripción:**
+Se requiere reducir duplicidades pendientes para facilitar mantenimiento y evolución.
+
+**Tareas:**
+- Unificar endpoint de renovación de token en la interfaz API.
+- Eliminar rutas o métodos redundantes no utilizados.
+- Revisar nombres y coherencia de modelos de datos.
+- Actualizar bitácora técnica con decisiones de simplificación.
+
+**Criterios de aceptación:**
+- Sin métodos duplicados de renovación en el contrato API.
+- Menor complejidad en flujo de autenticación y red.
+- Código más legible y consistente.
+
+**Estimación:** 3 puntos
+
+---
+
+## Definición de terminado del sprint
+
+- Todas las incidencias cerradas con solicitud de extracción vinculada.
+- Validación funcional completa del flujo SMS de extremo a extremo.
+- Bitácora de decisiones arquitectónicas actualizada.
+- Evidencias de pruebas manuales o automatizadas anexadas al hito.
+
+## Dependencias sugeridas
+
+1. Incidencia 1
+2. Incidencia 2
+3. Incidencia 3
+4. Incidencia 4
+5. Incidencia 6
+6. Incidencia 5
+
+## Comandos sugeridos (si se usa GitHub CLI)
+
+> Requiere repositorio con remoto configurado y autenticación previa con `gh auth login`.
+
+- Crear hito:
+  - `gh api repos/<owner>/<repo>/milestones -f title='Sprint 2 - Consolidación operativa SMS' -f state='open'`
+- Crear incidencia:
+  - `gh issue create --title '<titulo>' --body-file <archivo.md> --label sprint-2 --label prioridad:alta`
+

--- a/Documents/SPRINT_3_GITHUB_ISSUES.md
+++ b/Documents/SPRINT_3_GITHUB_ISSUES.md
@@ -1,0 +1,194 @@
+# Sprint 3 — Lista de incidencias para GitHub
+
+Este sprint implementa la **Fase 3** de la hoja de ruta: cobertura de pruebas automatizadas, mejora de calidad continua y documentación operativa.
+
+## Objetivo del sprint
+
+Elevar la calidad técnica del producto mediante pruebas de dominio, limpieza de configuración y documentación de operación por entorno.
+
+## Duración sugerida
+
+- 2 semanas
+
+## Estructura recomendada en GitHub
+
+- Hito: `Sprint 3 - Calidad continua y documentación`
+- Etiquetas sugeridas:
+  - `sprint-3`
+  - `calidad`
+  - `pruebas`
+  - `deuda-tecnica`
+  - `documentacion`
+  - `prioridad:media`
+
+---
+
+## Incidencia 1: Pruebas de expiración y renovación de token
+
+**Título sugerido:** `Pruebas: cubrir lógica de expiración y renovación de token`
+
+**Tipo:** Pruebas / Seguridad
+
+**Descripción:**
+La lógica de sesión debe estar respaldada con pruebas para reducir regresiones en autenticación.
+
+**Tareas:**
+- Crear pruebas unitarias para validación de expiración de token.
+- Simular escenarios de renovación exitosa y fallida.
+- Validar persistencia segura de token en flujo de renovación.
+- Documentar casos borde relevantes.
+
+**Criterios de aceptación:**
+- Cobertura de casos de token válido, vencido y malformado.
+- Renovación validada con resultados esperados.
+- No se introducen regresiones en login/logout.
+
+**Estimación:** 5 puntos
+
+---
+
+## Incidencia 2: Pruebas de validación de URLs por entorno
+
+**Título sugerido:** `Pruebas: validar reglas de configuración de URLs de entorno`
+
+**Tipo:** Pruebas / Configuración
+
+**Descripción:**
+La configuración de entornos debe ser predecible y segura, evitando URLs inválidas en operación.
+
+**Tareas:**
+- Crear pruebas unitarias para validación de esquema y host.
+- Cubrir casos válidos e inválidos por entorno.
+- Verificar persistencia de entorno activo y URL efectiva.
+- Agregar casos de regresión para cambios futuros.
+
+**Criterios de aceptación:**
+- Validación robusta de URLs con cobertura de casos límite.
+- No se permite guardar configuración inválida.
+- La URL activa coincide con el entorno seleccionado.
+
+**Estimación:** 3 puntos
+
+---
+
+## Incidencia 3: Pruebas de mapeo de estados de envío SMS
+
+**Título sugerido:** `Pruebas: cubrir mapeo de resultados de envío SMS a estados de negocio`
+
+**Tipo:** Pruebas / Mensajería
+
+**Descripción:**
+El mapeo de resultados del sistema Android a estados funcionales debe estar testeado para asegurar reportes correctos al backend.
+
+**Tareas:**
+- Probar mapeo de códigos de resultado a `ENVIADO` y `FALLIDO`.
+- Cubrir estados desconocidos y errores no contemplados.
+- Validar actualización de estado enviada al repositorio.
+- Documentar matriz de mapeo y comportamiento esperado.
+
+**Criterios de aceptación:**
+- Cobertura de todos los códigos utilizados en producción.
+- Mapeo consistente y estable ante cambios.
+- Sin inconsistencias entre resultado local y estado reportado.
+
+**Estimación:** 5 puntos
+
+---
+
+## Incidencia 4: Pruebas de reintentos y comportamiento de backoff
+
+**Título sugerido:** `Pruebas: verificar política de reintentos y backoff del flujo SMS`
+
+**Tipo:** Pruebas / Confiabilidad
+
+**Descripción:**
+La política de reintentos definida en Sprint 2 debe verificarse con pruebas para asegurar comportamiento estable bajo fallas repetidas.
+
+**Tareas:**
+- Implementar pruebas de tiempos de reintento y límites máximos.
+- Simular secuencias de error recuperable y no recuperable.
+- Verificar transición de estados ante recuperación de red.
+- Generar evidencia de comportamiento esperado.
+
+**Criterios de aceptación:**
+- Backoff aplicado según política definida.
+- No hay bucles agresivos de reintento.
+- El flujo se recupera cuando la causa del error desaparece.
+
+**Estimación:** 5 puntos
+
+---
+
+## Incidencia 5: Limpieza de dependencias y configuración de compilación
+
+**Título sugerido:** `Calidad: eliminar duplicidades de dependencias y sanear Gradle`
+
+**Tipo:** Calidad / Deuda técnica
+
+**Descripción:**
+Se requiere depurar dependencias repetidas y mejorar claridad de configuración para facilitar mantenimiento del build.
+
+**Tareas:**
+- Eliminar dependencias duplicadas en `build.gradle.kts`.
+- Revisar versiones y consistencia de bibliotecas principales.
+- Verificar compilación y pruebas después de la limpieza.
+- Registrar decisiones en bitácora técnica.
+
+**Criterios de aceptación:**
+- Archivo de build sin duplicidades obvias.
+- Compilación exitosa con configuración limpia.
+- Menor complejidad de mantenimiento del proyecto.
+
+**Estimación:** 3 puntos
+
+---
+
+## Incidencia 6: Documentación operativa por entorno y certificados
+
+**Título sugerido:** `Documentación: definir operación por entorno y gestión de certificados`
+
+**Tipo:** Documentación / Operación
+
+**Descripción:**
+La operación del agente requiere documentación clara para despliegue, soporte y rotación de certificados.
+
+**Tareas:**
+- Documentar flujo de despliegue para DEV, PREPROD y PROD.
+- Definir proceso de actualización y rotación de certificados.
+- Incluir checklist de verificación posterior al despliegue.
+- Publicar guía de respuesta ante incidentes de conectividad TLS.
+
+**Criterios de aceptación:**
+- Guía operativa completa y versionada en repositorio.
+- Procedimiento de certificados aplicable y verificable.
+- Equipo técnico puede ejecutar despliegue sin dependencias implícitas.
+
+**Estimación:** 3 puntos
+
+---
+
+## Definición de terminado del sprint
+
+- Todas las incidencias cerradas con solicitud de extracción vinculada.
+- Suite de pruebas de dominio integrada y ejecutándose en flujo de integración continua.
+- Configuración de compilación saneada y documentada.
+- Documentación operativa aprobada por responsables técnicos.
+
+## Dependencias sugeridas
+
+1. Incidencia 1
+2. Incidencia 2
+3. Incidencia 3
+4. Incidencia 4
+5. Incidencia 5
+6. Incidencia 6
+
+## Comandos sugeridos (si se usa GitHub CLI)
+
+> Requiere repositorio con remoto configurado y autenticación previa con `gh auth login`.
+
+- Crear hito:
+  - `gh api repos/<owner>/<repo>/milestones -f title='Sprint 3 - Calidad continua y documentación' -f state='open'`
+- Crear incidencia:
+  - `gh issue create --title '<titulo>' --body-file <archivo.md> --label sprint-3 --label prioridad:media`
+

--- a/project-management/commands/sprint_1_exec.md
+++ b/project-management/commands/sprint_1_exec.md
@@ -1,0 +1,249 @@
+# Sprint 1 — Ejecución
+
+```yaml
+version: 1
+sprint: "Sprint 1 - Seguridad y saneamiento"
+operations:
+  - create_issue:
+      title: "Definir política por sabor y tipo de compilación para DEV, PREPROD y PROD"
+      type: Security
+      labels: ["sprint-1", "seguridad", "android", "prioridad:alta"]
+      estimate: 1
+      body: |
+        Implementar la definición de política de red por sabor y tipo de compilación para DEV, PREPROD y PROD.
+
+        Criterio de aceptación relacionado:
+        - La excepción de tráfico en texto plano queda limitada y documentada por entorno.
+
+  - create_issue:
+      title: "Ajustar AndroidManifest.xml para no permitir tráfico en texto plano global"
+      type: Security
+      labels: ["sprint-1", "seguridad", "android", "prioridad:alta"]
+      estimate: 2
+      body: |
+        Ajustar AndroidManifest.xml para eliminar la habilitación global de tráfico en texto plano.
+
+        Criterios de aceptación relacionados:
+        - En producción no se permite tráfico HTTP plano.
+        - La aplicación mantiene conectividad en endpoints HTTPS válidos.
+
+  - create_issue:
+      title: "Configurar network_security_config específico por entorno"
+      type: Security
+      labels: ["sprint-1", "seguridad", "android", "prioridad:alta"]
+      estimate: 1
+      body: |
+        Configurar network_security_config por entorno para controlar excepciones de seguridad de red.
+
+        Criterio de aceptación relacionado:
+        - Las excepciones de texto plano quedan limitadas por entorno.
+
+  - create_issue:
+      title: "Validar conectividad HTTPS en cada entorno soportado"
+      type: Test
+      labels: ["sprint-1", "seguridad", "pruebas", "android", "prioridad:alta"]
+      estimate: 1
+      body: |
+        Ejecutar validaciones de conectividad HTTPS en DEV, PREPROD y PROD.
+
+        Criterio de aceptación relacionado:
+        - La aplicación mantiene conectividad en endpoints HTTPS válidos.
+
+  - create_issue:
+      title: "Condicionar HttpLoggingInterceptor por BuildConfig.DEBUG"
+      type: Security
+      labels: ["sprint-1", "seguridad", "android", "prioridad:alta"]
+      estimate: 1
+      body: |
+        Ajustar la configuración de logging HTTP para habilitar detalles solo en compilaciones de depuración.
+
+        Criterio de aceptación relacionado:
+        - En compilación de producción no se registran cuerpos de solicitud/respuesta.
+
+  - create_issue:
+      title: "Evitar impresión de Authorization y secretos en registros"
+      type: Security
+      labels: ["sprint-1", "seguridad", "android", "prioridad:alta"]
+      estimate: 1
+      body: |
+        Sanitizar registros para impedir exposición de cabeceras sensibles y secretos.
+
+        Criterio de aceptación relacionado:
+        - No se registran tokens ni cabeceras sensibles en ninguna compilación.
+
+  - create_issue:
+      title: "Revisar registros de errores para excluir tokens y datos personales"
+      type: Security
+      labels: ["sprint-1", "seguridad", "observabilidad", "prioridad:alta"]
+      estimate: 1
+      body: |
+        Revisar y corregir los registros de errores para evitar filtración de datos sensibles o personales.
+
+        Criterio de aceptación relacionado:
+        - No se exponen datos sensibles en registros.
+
+  - create_issue:
+      title: "Actualizar guía de depuración segura"
+      type: Docs
+      labels: ["sprint-1", "seguridad", "documentacion", "prioridad:alta"]
+      estimate: 1
+      body: |
+        Actualizar la guía de depuración segura con lineamientos de logging y tratamiento de datos sensibles.
+
+        Criterio de aceptación relacionado:
+        - Se mantiene trazabilidad útil sin comprometer seguridad.
+
+  - create_issue:
+      title: "Integrar almacenamiento cifrado para sesión"
+      type: Security
+      labels: ["sprint-1", "seguridad", "android", "prioridad:alta"]
+      estimate: 2
+      body: |
+        Integrar almacenamiento cifrado para persistencia de credenciales de sesión.
+
+        Criterio de aceptación relacionado:
+        - El token no se guarda en texto plano.
+
+  - create_issue:
+      title: "Implementar migración no disruptiva del token existente"
+      type: Fix
+      labels: ["sprint-1", "seguridad", "android", "prioridad:alta"]
+      estimate: 1
+      body: |
+        Implementar migración de token previo hacia almacenamiento cifrado sin afectar sesiones activas.
+
+        Criterio de aceptación relacionado:
+        - La sesión previa se migra correctamente sin romper el inicio de sesión.
+
+  - create_issue:
+      title: "Ajustar lectura y escritura de sesión en componentes afectados"
+      type: Refactor
+      labels: ["sprint-1", "arquitectura", "android", "prioridad:alta"]
+      estimate: 1
+      body: |
+        Ajustar los componentes que consumen sesión para usar el nuevo almacenamiento seguro.
+
+        Criterio de aceptación relacionado:
+        - Inicio de sesión, renovación y cierre de sesión funcionan correctamente.
+
+  - create_issue:
+      title: "Verificar inicio, renovación y cierre de sesión con almacenamiento cifrado"
+      type: Test
+      labels: ["sprint-1", "pruebas", "seguridad", "prioridad:alta"]
+      estimate: 1
+      body: |
+        Ejecutar validaciones funcionales para inicio, renovación y cierre de sesión tras la migración.
+
+        Criterio de aceptación relacionado:
+        - Cierre de sesión elimina credenciales de forma segura.
+
+  - create_issue:
+      title: "Definir decisión técnica del mecanismo único de ejecución SMS"
+      type: Refactor
+      labels: ["sprint-1", "arquitectura", "mensajeria", "prioridad:alta"]
+      estimate: 2
+      body: |
+        Definir y documentar la estrategia única de ejecución de envío SMS para operación estable.
+
+        Criterio de aceptación relacionado:
+        - Solo existe un flujo activo de envío de SMS.
+
+  - create_issue:
+      title: "Eliminar rutas no usadas y código muerto/comentado del flujo SMS"
+      type: Refactor
+      labels: ["sprint-1", "deuda-tecnica", "mensajeria", "prioridad:alta"]
+      estimate: 2
+      body: |
+        Eliminar rutas obsoletas y código muerto asociado al flujo alternativo de envío.
+
+        Criterio de aceptación relacionado:
+        - No hay doble programación ni competencia entre worker/servicio.
+
+  - create_issue:
+      title: "Ajustar reprogramación al reinicio con el mecanismo elegido"
+      type: Fix
+      labels: ["sprint-1", "mensajeria", "android", "prioridad:alta"]
+      estimate: 1
+      body: |
+        Ajustar la reprogramación de sincronización en reinicio para que use únicamente el flujo adoptado.
+
+        Criterio de aceptación relacionado:
+        - El flujo sigue operativo tras reinicio del dispositivo.
+
+  - create_issue:
+      title: "Validar ausencia de envíos duplicados en escenarios de reintento"
+      type: Test
+      labels: ["sprint-1", "pruebas", "mensajeria", "prioridad:alta"]
+      estimate: 1
+      body: |
+        Ejecutar pruebas de reintento para comprobar que no se produzcan envíos duplicados.
+
+        Criterio de aceptación relacionado:
+        - No hay competencia entre rutas ni duplicidad de envío.
+
+  - create_issue:
+      title: "Implementar requestCode único por mid en PendingIntent"
+      type: Fix
+      labels: ["sprint-1", "mensajeria", "confiabilidad", "prioridad:alta"]
+      estimate: 1
+      body: |
+        Ajustar la generación de requestCode para que sea único por mensaje y evitar colisiones.
+
+        Criterio de aceptación relacionado:
+        - Cada SMS mantiene correlación correcta con su confirmación de estado.
+
+  - create_issue:
+      title: "Revisar coherencia de PendingIntent en SmsSyncWorker y ruta adoptada"
+      type: Refactor
+      labels: ["sprint-1", "mensajeria", "android", "prioridad:alta"]
+      estimate: 1
+      body: |
+        Validar y unificar el patrón de construcción de PendingIntent en la ruta de envío vigente.
+
+        Criterio de aceptación relacionado:
+        - No se observan colisiones de intents entre mensajes.
+
+  - create_issue:
+      title: "Probar envío por lotes con resultados mixtos para detectar colisiones"
+      type: Test
+      labels: ["sprint-1", "pruebas", "mensajeria", "prioridad:alta"]
+      estimate: 1
+      body: |
+        Probar escenarios de envío por lotes con éxitos y fallos combinados para verificar correlación de estados.
+
+        Criterio de aceptación relacionado:
+        - No se observan colisiones en pruebas con lotes de mensajes.
+
+  - create_issue:
+      title: "Eliminar bloques comentados obsoletos del código fuente"
+      type: Refactor
+      labels: ["sprint-1", "deuda-tecnica", "android", "prioridad:alta"]
+      estimate: 1
+      body: |
+        Retirar implementaciones comentadas que ya no forman parte del diseño vigente.
+
+        Criterio de aceptación relacionado:
+        - Código fuente sin bloques comentados de implementaciones viejas.
+
+  - create_issue:
+      title: "Remover duplicidades en contrato API de renovación de token"
+      type: Refactor
+      labels: ["sprint-1", "deuda-tecnica", "arquitectura", "prioridad:alta"]
+      estimate: 1
+      body: |
+        Unificar métodos redundantes de renovación en la interfaz API para reducir complejidad.
+
+        Criterio de aceptación relacionado:
+        - Contrato de API sin duplicidades funcionales innecesarias.
+
+  - create_issue:
+      title: "Registrar decisiones técnicas del sprint en bitácora"
+      type: Docs
+      labels: ["sprint-1", "documentacion", "arquitectura", "prioridad:alta"]
+      estimate: 1
+      body: |
+        Documentar decisiones de arquitectura y seguridad adoptadas durante el sprint para trazabilidad.
+
+        Criterio de aceptación relacionado:
+        - Revisión de pares aprobada por legibilidad y mantenibilidad.
+```


### PR DESCRIPTION
### Motivation

- Proveer una revisión técnica del proyecto MCC Agent identificando riesgos de seguridad, arquitectura y deuda técnica para priorizar acciones.
- Definir una hoja de ruta operativa en tres fases y traducirla en listas de incidencias para sprints y tareas ejecutables.

### Description

- Se añaden los documentos de análisis y planificación: `Documents/REVISION_PROYECTO.md`, `Documents/SPRINT_1_GITHUB_ISSUES.md`, `Documents/SPRINT_2_GITHUB_ISSUES.md` y `Documents/SPRINT_3_GITHUB_ISSUES.md` con hallazgos, prioridades y criterios de aceptación por incidencia. 
- Se incorpora un archivo ejecutable de comandos para el Sprint 1 en `project-management/commands/sprint_1_exec.md` que contiene un YAML con tareas propuestas y plantillas de issues y estimaciones. 
- Los documentos priorizan mitigaciones de seguridad (cleartext, logging, almacenamiento de tokens), consolidación de la arquitectura de envío SMS (WorkManager vs Foreground Service), corrección de `PendingIntent` y limpieza de deuda técnica. 

### Testing

- No se ejecutaron pruebas automatizadas sobre código porque los cambios son exclusivamente de documentación y planificación; la compilación y las pruebas existentes del repositorio no se vieron afectadas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6cc7999948320b321a5435f0d9bd7)