### PR TITLE
Generar archivo ejecutable sprint_1_exec.md según plantilla

### DIFF
--- a/project-management/commands/sprint_1_exec.md
+++ b/project-management/commands/sprint_1_exec.md
@@ -1,181 +1,104 @@
+---
+id: sprint-1-seguridad-saneamiento
+title: Sprint 1 - Seguridad y saneamiento
+mode: apply
+---
+
 ```yaml
-milestone: "Sprint 1 - Seguridad y saneamiento"
+milestone:
+  title: "Sprint 1 - Seguridad y saneamiento"
+  description: "Endurecimiento de seguridad y limpieza inicial para estabilizar la operación con bajo impacto funcional y alto impacto en confiabilidad."
+  due_on: "2026-03-20"
+
 labels:
   - sprint-1
-  - prioridad:alta
+
 ops:
   - op: create_issue
-    create_issue:
-      title: "Definir política por sabor y tipo de compilación para DEV, PREPROD y PROD"
-      type: Security
-      estimate: 1
-      body: |
-        Definir política por sabor y tipo de compilación para DEV, PREPROD y PROD.
+    title: "Seguridad: restringir tráfico en texto plano y aplicar configuración de seguridad de red por entorno"
+    type: "Task"
+    labels: ["sprint-1", "seguridad", "android", "prioridad:alta"]
+    estimate: 5
+    body: |
+      Definir política por sabor y tipo de compilación para DEV, PREPROD y PROD.
+      Ajustar AndroidManifest.xml para no permitir tráfico en texto plano de forma global.
+      Configurar network_security_config específico por entorno.
+      Validar conectividad HTTPS en cada entorno soportado.
 
+      Criterios de aceptación:
+      - En producción no se permite tráfico HTTP plano.
+      - Cualquier excepción de texto plano queda limitada y documentada por entorno.
+      - La aplicación mantiene conectividad en endpoints válidos HTTPS.
   - op: create_issue
-    create_issue:
-      title: "Ajustar AndroidManifest.xml para no permitir tráfico en texto plano de forma global"
-      type: Security
-      estimate: 2
-      body: |
-        Ajustar AndroidManifest.xml para no permitir tráfico en texto plano de forma global.
+    title: "Seguridad: restringir registros HTTP a depuración y sanitizar credenciales"
+    type: "Task"
+    labels: ["sprint-1", "seguridad", "arquitectura", "prioridad:alta"]
+    estimate: 3
+    body: |
+      Condicionar HttpLoggingInterceptor por BuildConfig.DEBUG.
+      Evitar impresión de Authorization y otros secretos.
+      Revisar registros de errores para no incluir tokens ni datos personales.
+      Actualizar guía de depuración segura.
 
+      Criterios de aceptación:
+      - En compilación de producción no se registran cuerpos de solicitud/respuesta.
+      - No se registran tokens ni cabeceras sensibles en ninguna compilación.
+      - Se conserva trazabilidad suficiente para diagnóstico técnico.
   - op: create_issue
-    create_issue:
-      title: "Configurar network_security_config específico por entorno"
-      type: Security
-      estimate: 1
-      body: |
-        Configurar network_security_config específico por entorno.
+    title: "Seguridad: migrar sesión a almacenamiento cifrado"
+    type: "Feature"
+    labels: ["sprint-1", "seguridad", "android", "prioridad:alta"]
+    estimate: 5
+    body: |
+      Integrar almacenamiento cifrado (EncryptedSharedPreferences o equivalente).
+      Implementar migración no disruptiva de token existente.
+      Ajustar lectura/escritura de sesión en componentes afectados.
+      Verificar comportamiento de inicio de sesión, renovación y cierre de sesión.
 
+      Criterios de aceptación:
+      - El token no se guarda en texto plano.
+      - La sesión previa se migra correctamente sin romper el inicio de sesión.
+      - El cierre de sesión elimina credenciales de forma segura.
   - op: create_issue
-    create_issue:
-      title: "Validar conectividad HTTPS en cada entorno soportado"
-      type: Test
-      estimate: 1
-      body: |
-        Validar conectividad HTTPS en cada entorno soportado.
+    title: "Arquitectura: consolidar envío SMS en un único mecanismo de ejecución"
+    type: "Task"
+    labels: ["sprint-1", "arquitectura", "android", "prioridad:alta"]
+    estimate: 8
+    body: |
+      Definir decisión técnica (preferencia sugerida: WorkManager para sincronización periódica controlada).
+      Eliminar rutas no usadas y código muerto/comentado.
+      Ajustar reprogramación en reinicio al mecanismo elegido.
+      Validar ausencia de envíos duplicados en escenarios de reintento.
 
+      Criterios de aceptación:
+      - Solo existe un flujo activo de envío de SMS.
+      - No hay doble programación ni competencia entre worker/servicio.
+      - El flujo sigue operativo tras reinicio del dispositivo.
   - op: create_issue
-    create_issue:
-      title: "Condicionar HttpLoggingInterceptor por BuildConfig.DEBUG"
-      type: Security
-      estimate: 1
-      body: |
-        Condicionar HttpLoggingInterceptor por BuildConfig.DEBUG.
+    title: "Confiabilidad: evitar colisiones de PendingIntent por mensaje"
+    type: "Bug"
+    labels: ["sprint-1", "android", "prioridad:alta"]
+    estimate: 3
+    body: |
+      Usar requestCode único por mid (por ejemplo mid.hashCode()).
+      Revisar coherencia en SmsSyncWorker y en la ruta de envío adoptada.
+      Probar múltiples mensajes en cola con resultados mixtos (éxito/fallo).
 
+      Criterios de aceptación:
+      - Cada SMS mantiene correlación correcta con su confirmación de estado.
+      - No se observan colisiones en pruebas con lotes de mensajes.
   - op: create_issue
-    create_issue:
-      title: "Evitar impresión de Authorization y otros secretos"
-      type: Security
-      estimate: 1
-      body: |
-        Evitar impresión de Authorization y otros secretos.
+    title: "Deuda técnica: eliminar código comentado legado y duplicidades inmediatas"
+    type: "Task"
+    labels: ["sprint-1", "deuda-tecnica", "prioridad:alta"]
+    estimate: 3
+    body: |
+      Eliminar bloques comentados obsoletos.
+      Remover duplicidades obvias en contrato API (renovación de token duplicada).
+      Registrar decisiones en bitácora técnica del sprint.
 
-  - op: create_issue
-    create_issue:
-      title: "Revisar registros de errores para no incluir tokens ni datos personales"
-      type: Security
-      estimate: 1
-      body: |
-        Revisar registros de errores para no incluir tokens ni datos personales.
-
-  - op: create_issue
-    create_issue:
-      title: "Actualizar guía de depuración segura"
-      type: Docs
-      estimate: 1
-      body: |
-        Actualizar guía de depuración segura.
-
-  - op: create_issue
-    create_issue:
-      title: "Integrar almacenamiento cifrado para sesión"
-      type: Security
-      estimate: 2
-      body: |
-        Integrar almacenamiento cifrado (EncryptedSharedPreferences o equivalente).
-
-  - op: create_issue
-    create_issue:
-      title: "Implementar migración no disruptiva de token existente"
-      type: Fix
-      estimate: 1
-      body: |
-        Implementar migración no disruptiva de token existente.
-
-  - op: create_issue
-    create_issue:
-      title: "Ajustar lectura y escritura de sesión en componentes afectados"
-      type: Refactor
-      estimate: 1
-      body: |
-        Ajustar lectura y escritura de sesión en componentes afectados.
-
-  - op: create_issue
-    create_issue:
-      title: "Verificar inicio de sesión, renovación y cierre de sesión"
-      type: Test
-      estimate: 1
-      body: |
-        Verificar comportamiento de inicio de sesión, renovación y cierre de sesión.
-
-  - op: create_issue
-    create_issue:
-      title: "Definir decisión técnica del mecanismo único de ejecución SMS"
-      type: Refactor
-      estimate: 2
-      body: |
-        Definir decisión técnica del mecanismo único de ejecución SMS.
-
-  - op: create_issue
-    create_issue:
-      title: "Eliminar rutas no usadas y código muerto o comentado"
-      type: Refactor
-      estimate: 2
-      body: |
-        Eliminar rutas no usadas y código muerto o comentado.
-
-  - op: create_issue
-    create_issue:
-      title: "Ajustar reprogramación en reinicio al mecanismo elegido"
-      type: Fix
-      estimate: 1
-      body: |
-        Ajustar reprogramación en reinicio al mecanismo elegido.
-
-  - op: create_issue
-    create_issue:
-      title: "Validar ausencia de envíos duplicados en escenarios de reintento"
-      type: Test
-      estimate: 1
-      body: |
-        Validar ausencia de envíos duplicados en escenarios de reintento.
-
-  - op: create_issue
-    create_issue:
-      title: "Usar requestCode único por mid"
-      type: Fix
-      estimate: 1
-      body: |
-        Usar requestCode único por mid (por ejemplo mid.hashCode()).
-
-  - op: create_issue
-    create_issue:
-      title: "Revisar coherencia de requestCode en SmsSyncWorker y ruta adoptada"
-      type: Refactor
-      estimate: 1
-      body: |
-        Revisar coherencia de requestCode en SmsSyncWorker y ruta de envío adoptada.
-
-  - op: create_issue
-    create_issue:
-      title: "Probar múltiples mensajes en cola con resultados mixtos"
-      type: Test
-      estimate: 1
-      body: |
-        Probar múltiples mensajes en cola con resultados mixtos (éxito y fallo).
-
-  - op: create_issue
-    create_issue:
-      title: "Eliminar bloques comentados obsoletos"
-      type: Refactor
-      estimate: 1
-      body: |
-        Eliminar bloques comentados obsoletos.
-
-  - op: create_issue
-    create_issue:
-      title: "Remover duplicidades en contrato API de renovación"
-      type: Refactor
-      estimate: 1
-      body: |
-        Remover duplicidades obvias en contrato API (renovación de token duplicada).
-
-  - op: create_issue
-    create_issue:
-      title: "Registrar decisiones en bitácora técnica del sprint"
-      type: Docs
-      estimate: 1
-      body: |
-        Registrar decisiones en bitácora técnica del sprintgit
+      Criterios de aceptación:
+      - Código fuente sin bloques comentados de implementaciones viejas.
+      - Contrato de API sin duplicidades funcionales innecesarias.
+      - Revisión de pares aprobada por legibilidad y mantenibilidad.
+```


### PR DESCRIPTION
### Motivation
- Convertir el documento de planificación del Sprint 1 en un comando ejecutable que cumpla exactamente la estructura definida en `project-management/templates/_template_sprint.md` para que el motor PM (`pm-apply.mjs`) pueda procesarlo.

### Description
- Se creó/actualizó `project-management/commands/sprint_1_exec.md` con `front matter` (`id`, `title`, `mode`) seguido del bloque ```yaml``` que contiene `milestone` (con `title`, `description`, `due_on`), `labels` y la lista `ops` según la plantilla. 
- Se mapearon las incidencias del `Documents/SPRINT_1_GITHUB_ISSUES.md` a 6 operaciones `create_issue` respetando exactamente las propiedades permitidas por la plantilla (`op`, `title`, `type`, `labels`, `estimate`, `body`) y manteniendo el contenido en español técnico. 
- Se eliminaron estructuras anidadas e incompatibles previas y se normalizó el formato YAML para compatibilidad con `project-management/scripts/pm-apply.mjs`.

### Testing
- Inspección del archivo con `nl`/`sed` para verificar la presencia del `front matter` y del bloque YAML (éxito). 
- Comparación tipo diff del archivo para confirmar que la estructura quedó alineada con la plantilla (éxito). 
- Intento de validación YAML con un `node` one-liner que carga `js-yaml` falló por ausencia del módulo `js-yaml` en el entorno, por lo que la verificación de parseo YAML quedó pendiente por falta de dependencia (fallo parcial).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8468c7964832084d6d733411e2085)